### PR TITLE
Tweak CMakeLists.txt to generate 'liblgl.a' as well as 'lingeling'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,13 +7,17 @@ find_package (Threads REQUIRED)
 add_definitions(-DNCHKSOL)
 add_definitions(-DNLGLPICOSAT)
 
-
-add_executable(lingeling
+add_library(lgl
     lglbnr.c
     lglib.c
+)
+
+add_executable(lingeling
     lglmain.c
 )
+
 target_link_libraries(lingeling
+    LINK_PRIVATE lgl
     LINK_PUBLIC ${CMAKE_THREAD_LIBS_INIT}
     m
 )


### PR DESCRIPTION
## Issue

The current CMakeLists.txt only builds `lingeling` the application, and not `liblgl.a` the static archive. This is an issue when trying to build Boolector against a Lingeling built with this CMakeLists.txt.

## Resolution

This PR changes is such that running `cmake` generates `liblgl.a`, and links `lingeling` against the static archive.

This will then allow Boolector to find `liblgl.a`.

Signed-off-by: Andrew V. Jones <andrew.jones@vector.com>